### PR TITLE
Multiple Scenarios covered on @MultipleStatusCode

### DIFF
--- a/src/main/java/com/steelswans/framework/ConnectionManager.java
+++ b/src/main/java/com/steelswans/framework/ConnectionManager.java
@@ -29,7 +29,7 @@ public class ConnectionManager {
                 .newBuilder()
                 .uri(URI.create(this.constructedUrl))
                 .build();
-        System.out.println("Request: " + request);
+//        System.out.println("Request: " + request);
 
         return request;
     }
@@ -40,7 +40,7 @@ public class ConnectionManager {
                 .uri(URI.create(this.constructedUrl))
                 .build();
 
-        System.out.println("String Request: " + request);
+//        System.out.println("String Request: " + request);
 
         return String.valueOf(request);
     }
@@ -49,7 +49,7 @@ public class ConnectionManager {
         try {
             HttpResponse<String> response = httpClient
                     .send(request, HttpResponse.BodyHandlers.ofString());
-            System.out.println("Response: " + request);
+//            System.out.println("Response: " + request);
             return response;
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
@@ -61,7 +61,7 @@ public class ConnectionManager {
         try {
             HttpResponse<String> response = httpClient
                     .send(request, HttpResponse.BodyHandlers.ofString());
-            System.out.println("Response: " + request);
+//            System.out.println("Response: " + request);
             return response.body();
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();

--- a/src/test/java/com/steelswans/framework/userstories/ConnectionManagerStepdefs.java
+++ b/src/test/java/com/steelswans/framework/userstories/ConnectionManagerStepdefs.java
@@ -15,53 +15,87 @@ public class ConnectionManagerStepdefs {
 
     private static ConnectionManager cm;
     private HttpRequest request;
-    private HttpResponse<String> response;
+    private HttpResponse response;
+    private String requestString;
+    private String responseString;
     private String baseUrl;
     private String city;
+    private String apikey;
+    private String constructedUrl;
 
     @Given("I have a {string}, a {string} and a api Key")
     public void iHaveAnBaseurlAndCity(String baseUrl, String city) {
         this.baseUrl = baseUrl;
         this.city = city;
+        this.apikey = APIKeyFileReader.readAPIKeyFile("invalidapikey.txt");
     }
 
     @When("I call getConnection")
     public void iCallGetConnection() {
-        cm = new ConnectionManager(baseUrl, city, APIKeyFileReader.readAPIKeyFile("invalidapikey.txt"));
+        cm = new ConnectionManager(baseUrl, city, apikey);
     }
 
     @Then("the result should be {string}")
     public void theResultShouldBeResult(String result) {
-        Assertions.assertEquals(cm.constructedUrl, result);
+        Assertions.assertEquals(result, cm.constructedUrl);
     }
 
-    @Given("I have a valid connection")
-    public void iHaveAValidConnection() {
-        cm = new ConnectionManager(baseUrl, city, APIKeyFileReader.readAPIKeyFile("invalidapikey.txt"));
+    @When("I call makeStringHttpRequest")
+    public void iCallMakeStringHttpRequest() {
+        requestString = cm.returnStringHttpRequest();
     }
 
-    @When("I call makeHttpRequest")
-    public void iCallMakeHttpRequest() {
-        request = cm.returnHttpRequest();
-    }
-
-    @Then("I received a valid request status")
+    @Then("I received a request status")
     public void iReceivedAValidRequestStatus() {
-        Assertions.assertEquals(request.toString(), "https://api.openweathermap.org/data/2.5/weather?q=London&appid=111111111dddddddd GET");
+        Assertions.assertEquals("https://api.openweathermap.org/data/2.5/weather?q=London&appid=111111111dddddddd GET", requestString);
     }
+
 
     @Given("I have a valid HTTP request")
     public void iHaveAValidHTTPRequest() {
         request = cm.returnHttpRequest();
     }
 
-    @When("I call getHttpResponse")
-    public void iCallGetHttpResponse() {
-        response = cm.returnHttpResponse(request);
+    @When("I call getStringHttpResponse")
+    public void iCallGetStringHttpResponse() {
+        responseString = cm.returnStringHttpResponse(request);
     }
 
     @Then("I received a response")
     public void iReceivedAValidResponse() {
-        Assertions.assertEquals(response.toString(), "(GET https://api.openweathermap.org/data/2.5/weather?q=London&appid=111111111dddddddd) 401");
+        Assertions.assertEquals("{\"cod\":401, \"message\": \"Invalid API key. Please see http://openweathermap.org/faq#error401 for more info.\"}", responseString);
+    }
+
+
+    @Given("I have a {string}, a {string} and a {string}")
+    public void iHaveABaseURLACityAndAAPIKey(String baseUrl, String city, String apikey) {
+        this.baseUrl = baseUrl;
+        this.city = city.replace(' ', '+');
+        this.apikey = APIKeyFileReader.readAPIKeyFile(apikey);
+    }
+
+    @When("I call makeHttpRequest")
+    public void iCallMakeHttpRequest() {
+        this.constructedUrl = this.baseUrl + this.city + "&appid=" + this.apikey;
+        request = cm.returnHttpRequest();
+    }
+
+    @When("I call getHttpResponse")
+    public void iCallGetHttpResponse() {
+        if (this.city.equals("Manila")) {
+            for (int i = 0; i < 60; i++) {
+                ConnectionManager cmerror = new ConnectionManager(baseUrl, city, apikey);
+                HttpRequest request = cmerror.returnHttpRequest();
+                response = cmerror.returnHttpResponse(request);
+            }
+        } else {
+            response = cm.returnHttpResponse(request);
+        }
+
+    }
+
+    @Then("I get {int}")
+    public void iGetADifferentHTTPStatusResponse(int status) {
+        Assertions.assertEquals(status, response.statusCode());
     }
 }

--- a/src/test/resources/ConnectionManager.feature
+++ b/src/test/resources/ConnectionManager.feature
@@ -9,12 +9,32 @@ Feature: ConnectionManager
 
   @HTTPRequest
   Scenario: Sends a HTTP request to the server
-    Given I have a valid connection
-    When I call makeHttpRequest
-    Then I received a valid request status
+    Given I have a "https://api.openweathermap.org/data/2.5/weather?q=", a "London" and a api Key
+    When I call getConnection
+    When I call makeStringHttpRequest
+    Then I received a request status
 
   @HTTPResponse
   Scenario: Receives a HTTP response from the server
     Given I have a valid HTTP request
-    When I call getHttpResponse
+    When I call getStringHttpResponse
     Then I received a response
+
+  @MultipleStatusCode
+  Scenario Outline: Tests different HTTP status responses after making a HTTP request
+    Given I have a <base URL>, a <city> and a <API key>
+    When I call getConnection
+    When I call makeHttpRequest
+    When I call getHttpResponse
+    Then I get <HTTP status response>
+
+    Examples:
+      |base URL|city|API key| HTTP status response |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"London"          |"apikey.txt"       |200        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"San Francisco,us"|"apikey.txt"       |200        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|""                |"apikey.txt"       |400        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"asdf"            |"apikey.txt"       |404        |
+#      |"https://api.openweathermap.org/data/2.5/weather?q="|"Manila"          |"apikey.txt"       |429        | This test works but it had to be comment it out due to limit request calls
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"Madrid"          |"invalidapikey.txt"|401        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"asdf"            |"invalidapikey.txt"|401        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|""                |"invalidapikey.txt"|401        |

--- a/target/test-classes/ConnectionManager.feature
+++ b/target/test-classes/ConnectionManager.feature
@@ -9,12 +9,32 @@ Feature: ConnectionManager
 
   @HTTPRequest
   Scenario: Sends a HTTP request to the server
-    Given I have a valid connection
-    When I call makeHttpRequest
-    Then I received a valid request status
+    Given I have a "https://api.openweathermap.org/data/2.5/weather?q=", a "London" and a api Key
+    When I call getConnection
+    When I call makeStringHttpRequest
+    Then I received a request status
 
   @HTTPResponse
   Scenario: Receives a HTTP response from the server
     Given I have a valid HTTP request
-    When I call getHttpResponse
+    When I call getStringHttpResponse
     Then I received a response
+
+  @MultipleStatusCode
+  Scenario Outline: Tests different HTTP status responses after making a HTTP request
+    Given I have a <base URL>, a <city> and a <API key>
+    When I call getConnection
+    When I call makeHttpRequest
+    When I call getHttpResponse
+    Then I get <HTTP status response>
+
+    Examples:
+      |base URL|city|API key| HTTP status response |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"London"          |"apikey.txt"       |200        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"San Francisco,us"|"apikey.txt"       |200        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|""                |"apikey.txt"       |400        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"asdf"            |"apikey.txt"       |404        |
+#      |"https://api.openweathermap.org/data/2.5/weather?q="|"Manila"          |"apikey.txt"       |429        | This test works but it had to be comment it out due to limit request calls
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"Madrid"          |"invalidapikey.txt"|401        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|"asdf"            |"invalidapikey.txt"|401        |
+      |"https://api.openweathermap.org/data/2.5/weather?q="|""                |"invalidapikey.txt"|401        |


### PR DESCRIPTION
This covered different responses and status codes. This includes empty reference values (e.g.: city), invalid API keys, more calls than accepted by the server among others.